### PR TITLE
Fix a small issue related to numpy in metrics.py 

### DIFF
--- a/spm1d/stats/nonparam/metrics.py
+++ b/spm1d/stats/nonparam/metrics.py
@@ -25,21 +25,14 @@ class _Metric(object):
 		L,n     = bwlabel(z>thresh)
 		x       = [0]
 		if n > 0:
-			x = list()
-			for i in range(n):
-				temp = self.get_single_cluster_metric(z, thresh, L==i+1)
-				if isinstance(temp, list) or isinstance(temp, np.ndarray):
-					for j in temp:
-						x.append(j)
-				else:
-					x.append(temp)
+			x   = [self.get_single_cluster_metric(z, thresh, L==i+1)   for i in range(n)]
 			if circular and (n > 1):  #merge clusters for circular fields:
 				if (L==1)[0] and (L==n)[-1]:
 					x[0] += x[-1]
 					x     = x[:-1]
 		return x
 	def get_max_metric(self, z, thresh=3.0, circular=False):
-		return np.max(  self.get_all_cluster_metrics(z, thresh, circular)  )
+		return max(  self.get_all_cluster_metrics(z, thresh, circular)  )
 
 
 class MaxClusterExtent(_Metric):
@@ -59,7 +52,7 @@ class MaxClusterHeight(_Metric):
 class MaxClusterIntegral(_Metric):
 	def get_single_cluster_metric(self, z, thresh, i):
 		if i.sum()==1:
-			x = z[i] - thresh
+			x = float(z[i]) - thresh
 		else:
 			x = np.trapz(  z[i]-thresh  )
 		return x

--- a/spm1d/stats/nonparam/metrics.py
+++ b/spm1d/stats/nonparam/metrics.py
@@ -32,7 +32,7 @@ class _Metric(object):
 					x     = x[:-1]
 		return x
 	def get_max_metric(self, z, thresh=3.0, circular=False):
-		return max(  self.get_all_cluster_metrics(z, thresh, circular)  )
+		return np.max(  self.get_all_cluster_metrics(z, thresh, circular)  )
 
 
 class MaxClusterExtent(_Metric):

--- a/spm1d/stats/nonparam/metrics.py
+++ b/spm1d/stats/nonparam/metrics.py
@@ -25,7 +25,14 @@ class _Metric(object):
 		L,n     = bwlabel(z>thresh)
 		x       = [0]
 		if n > 0:
-			x   = [self.get_single_cluster_metric(z, thresh, L==i+1)   for i in range(n)]
+			x = list()
+			for i in range(n):
+				temp = self.get_single_cluster_metric(z, thresh, L==i+1)
+				if isinstance(temp, list) or isinstance(temp, np.ndarray):
+					for j in temp:
+						x.append(j)
+				else:
+					x.append(temp)
 			if circular and (n > 1):  #merge clusters for circular fields:
 				if (L==1)[0] and (L==n)[-1]:
 					x[0] += x[-1]


### PR DESCRIPTION
Hi, regarding https://github.com/0todd0000/spm1d/issues/262, I found that [x](https://github.com/0todd0000/spm1d/blob/3636afb69f7a675e6e968db2093474dd85952e1f/spm1d/stats/nonparam/metrics.py#L33) may be a list of numpy arrays, e.g., `[array([0.30227087])]` and `max(x)` returns a list, e.g., `[0.30227087]`.

That was the source of the issue. Using `numpy.max` instead of `max` can handle it and return a value.